### PR TITLE
Updated to support sqlx 0.5.x

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ormx = { path = "../ormx", features = ["postgres"] }
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 anyhow = "1"
 dotenv = "0.15"
 chrono = "0.4"
@@ -14,6 +14,6 @@ simple_logger = "1"
 log = "0.4"
 
 [dependencies.sqlx]
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["macros", "postgres", "runtime-tokio-rustls", "chrono", "offline"]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -93,7 +93,7 @@ struct UpdateName {
 }
 
 #[derive(Debug, Copy, Clone, sqlx::Type)]
-#[sqlx(rename = "user_role")]
+#[sqlx(type_name = "user_role")]
 #[sqlx(rename_all = "lowercase")]
 enum Role {
     User,

--- a/ormx-macros/Cargo.toml
+++ b/ormx-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormx-macros"
-version = "0.1.8"
+version = "0.2.0"
 authors = ["moritz"]
 edition = "2018"
 description = "lightweight procedural macros bringing orm-like features to sqlx"
@@ -16,7 +16,7 @@ mysql = []
 postgres = []
 
 [dependencies]
-itertools = "0.9"
+itertools = "0.10"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1", features = ["full"] }

--- a/ormx-macros/src/backend/common/table.rs
+++ b/ormx-macros/src/backend/common/table.rs
@@ -1,6 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::quote;
-use syn::export::TokenStreamExt;
+use quote::{TokenStreamExt, quote};
 
 use crate::backend::Backend;
 use crate::table::Table;

--- a/ormx/Cargo.toml
+++ b/ormx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ormx"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Moritz Bischof"]
 edition = "2018"
 license = "MIT"
@@ -20,14 +20,14 @@ postgres = ["sqlx/postgres", "ormx-macros/postgres"]
 _docs-rs-build = ["sqlx/runtime-tokio-rustls", "postgres"]
 
 [dependencies]
-ormx-macros = { path = "../ormx-macros", version = "0.1" }
+ormx-macros = { path = "../ormx-macros", version = "0.2" }
 futures = "0.3"
 
 [dependencies.sqlx]
-version = "0.4"
+version = "0.5"
 default-features = false
 features = ["macros"]
 
 [dev-dependencies]
-tokio = { version = "0.3", features = ["full"] }
+tokio = { version = "1.1", features = ["full"] }
 anyhow = "1"

--- a/ormx/src/query2/map.rs
+++ b/ormx/src/query2/map.rs
@@ -1,5 +1,5 @@
 use futures::stream::BoxStream;
-use sqlx::{Database, Executor, IntoArguments, query::{Map, TryMapRow}};
+use sqlx::{Database, Executor, IntoArguments, Error, query::Map};
 
 #[doc(hidden)]
 #[macro_export]
@@ -30,7 +30,7 @@ macro_rules! make_conditional_map_ty {
             DB: Database,
             O: Send + Unpin,
             $(
-                $ff: TryMapRow<DB, Output = O>,
+                $ff: FnMut(DB::Row) -> Result<O, Error> + Send,
                 $fa: 'q + Send + IntoArguments<'q, DB>,
             )*
         {
@@ -41,7 +41,7 @@ macro_rules! make_conditional_map_ty {
             DB: Database,
             O: Send + Unpin,
             $(
-                $ff: TryMapRow<DB, Output = O>,
+                $ff: FnMut(DB::Row) -> Result<O, Error> + Send,
                 $fa: 'q + Send + IntoArguments<'q, DB>,
             )*
         {

--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -1,9 +1,9 @@
 CONTAINER_ID=$(
-  docker run -it --rm --name ormx-test-mariadb-db \
+  docker run -it --rm --name ormx-test-mysql-db \
     -e MYSQL_DATABASE=ormx \
     -e MYSQL_ROOT_PASSWORD=admin \
     -v $(pwd)/scripts/mysql-schema.sql:/docker-entrypoint-initdb.d/schema.sql \
-    -d mariadb
+    -d mysql
 )
 CONTAINER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $CONTAINER_ID)
 echo "DATABASE_URL=mysql://root:admin@$CONTAINER_IP/ormx" > .env


### PR DESCRIPTION
Hello! 

This PR updates `ormx` to support `sqlx` version 0.5.0 and also closes #4 

# List of changes


## Added

* Separate script to test MySQL database at `scripts/mysql.sh`

## Changed

* Updated `sqlx` to 0.5
* Updated `tokio` test dependencies to 1.1
* Bumped `ormx` to 0.3.0 and `ormx-macros` to 0.2.0

## Fixed

* Fixed missing export in the `syn` crate
	* They previously re-exported `quote` through a public `exports` module but that was always documented as a "private API" which they since removed. `TokenStreamExt` is now imported from `quote`.
