### PR TITLE
fix update() assigning values to columns marked with `default`

### DIFF
--- a/ormx-macros/src/backend/common/table.rs
+++ b/ormx-macros/src/backend/common/table.rs
@@ -59,7 +59,7 @@ fn update<B: Backend>(table: &Table<B>) -> TokenStream {
     let box_future = crate::utils::box_future();
     let mut bindings = B::Bindings::default();
     let mut assignments = vec![];
-    for field in table.fields_except_id() {
+    for field in table.insertable_fields_except_id() {
         let fragment = format!("{} = {}", field.column(), bindings.next().unwrap());
         assignments.push(fragment);
     }
@@ -73,7 +73,7 @@ fn update<B: Backend>(table: &Table<B>) -> TokenStream {
         bindings.next().unwrap()
     );
     let id_argument = &table.id.field;
-    let other_arguments = table.fields_except_id().map(|field| {
+    let other_arguments = table.insertable_fields_except_id().map(|field| {
         let ident = &field.field;
         let mut out = quote!(self.#ident);
 

--- a/ormx-macros/src/table/mod.rs
+++ b/ormx-macros/src/table/mod.rs
@@ -46,6 +46,11 @@ impl<B: Backend> Table<B> {
         self.fields.iter().filter(|field| !field.default)
     }
 
+    pub fn insertable_fields_except_id(&self) -> impl Iterator<Item = &TableField<B>> + Clone {
+        let id = self.id.field.clone();
+        self.fields.iter().filter(move |field| field.field != id && !field.default)
+    }
+
     pub fn default_fields(&self) -> impl Iterator<Item = &TableField<B>> + Clone {
         self.fields.iter().filter(|field| field.default)
     }


### PR DESCRIPTION
This fixes a bug where `update()` does not exclude generated columns annotated with `default` attribute, leading to compilation errors when using `#[derive(ormx::Table)]` with postgres:
```
error returned from database: column "foo" can only be updated to DEFAULT
```