### PR TITLE
Postgres: get_by_any getters

### DIFF
--- a/example-postgres/src/main.rs
+++ b/example-postgres/src/main.rs
@@ -67,7 +67,7 @@ async fn main() -> anyhow::Result<()> {
     insert_dummy_user(&mut conn, 4).await?;
 
     log::info!("getting many users by any user id (using 'get_any' getter)");
-    let users = User::get_many_by_user_ids(&mut conn, &[2, 4]).await?;
+    let users = User::get_by_any_user_id(&mut conn, &[2, 4]).await?;
     dbg!(&users);
     assert_eq!(users.len(), 2);
 
@@ -95,7 +95,7 @@ struct User {
     // map this field to the column "id"
     #[ormx(column = "id")]
     #[ormx(get_one = get_by_user_id)]
-    #[ormx(get_any = get_many_by_user_ids)]
+    #[ormx(get_by_any)]
     user_id: i32,
     first_name: String,
     last_name: String,

--- a/ormx-macros/src/attrs.rs
+++ b/ormx-macros/src/attrs.rs
@@ -29,9 +29,9 @@ pub enum TableFieldAttr {
     GetOptional(Getter),
     // get_many [= <ident>]? [(<type>)]?
     GetMany(Getter),
-    // get_many [= <ident>]? [(<type>)]?
+    // get_by_any [= <ident>]? [(<type>)]?
     #[cfg(feature = "postgres")]
-    GetAny(Getter),
+    GetByAny(Getter),
     // set [= <ident>]?
     Set(Option<Ident>),
 }
@@ -147,7 +147,7 @@ impl_parse!(TableFieldAttr {
     "get_optional" => GetOptional(Getter),
     "get_many" => GetMany(Getter),
     #[cfg(feature = "postgres")]
-    "get_any" => GetAny(Getter),
+    "get_by_any" => GetByAny(Getter),
     "set" => Set((= Ident)?),
     "custom_type" => CustomType(),
     "default" => Default()

--- a/ormx-macros/src/backend/postgres/get_any.rs
+++ b/ormx-macros/src/backend/postgres/get_any.rs
@@ -1,0 +1,41 @@
+use crate::{
+    backend::{common, postgres::PgBindings},
+    table::Table,
+};
+
+use super::PgBackend;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+pub(crate) fn impl_get_any_getter(table: &Table<PgBackend>) -> TokenStream {
+    let column_list = table.select_column_list();
+    let vis = &table.vis;
+    let mut getters = TokenStream::new();
+
+    for field in table.fields.iter() {
+        if let Some(getter) = &field.get_any {
+            let sql = format!(
+                "SELECT {} FROM {} WHERE {} = ANY({})",
+                column_list,
+                table.table,
+                field.column(),
+                PgBindings::default().next().unwrap()
+            );
+
+            let func = getter.ident_or_fallback(&field);
+            let arg = getter.arg_ty.clone().unwrap_or_else(|| {
+                let ty = &field.ty;
+                syn::parse2(quote!(&[#ty])).unwrap()
+            });
+
+            getters.extend(common::get_many(vis, &func, &arg, &sql));
+        }
+    }
+
+    let table_ident = &table.ident;
+    quote! {
+        impl #table_ident {
+            #getters
+        }
+    }
+}

--- a/ormx-macros/src/backend/postgres/get_by_any.rs
+++ b/ormx-macros/src/backend/postgres/get_by_any.rs
@@ -7,13 +7,13 @@ use super::PgBackend;
 use proc_macro2::TokenStream;
 use quote::quote;
 
-pub(crate) fn impl_get_any_getter(table: &Table<PgBackend>) -> TokenStream {
+pub(crate) fn impl_get_by_any_getter(table: &Table<PgBackend>) -> TokenStream {
     let column_list = table.select_column_list();
     let vis = &table.vis;
     let mut getters = TokenStream::new();
 
     for field in table.fields.iter() {
-        if let Some(getter) = &field.get_any {
+        if let Some(getter) = &field.get_by_any {
             let sql = format!(
                 "SELECT {} FROM {} WHERE {} = ANY({})",
                 column_list,
@@ -22,7 +22,7 @@ pub(crate) fn impl_get_any_getter(table: &Table<PgBackend>) -> TokenStream {
                 PgBindings::default().next().unwrap()
             );
 
-            let func = getter.ident_or_fallback(&field);
+            let func = getter.ident_or(&field, &format!("get_by_any_{}", field.field));
             let arg = getter.arg_ty.clone().unwrap_or_else(|| {
                 let ty = &field.ty;
                 syn::parse2(quote!(&[#ty])).unwrap()

--- a/ormx-macros/src/backend/postgres/mod.rs
+++ b/ormx-macros/src/backend/postgres/mod.rs
@@ -5,6 +5,11 @@ use proc_macro2::TokenStream;
 use crate::backend::Backend;
 use crate::table::Table;
 
+use self::get_any::impl_get_any_getter;
+
+use super::common;
+
+mod get_any;
 mod insert;
 
 #[derive(Clone)]
@@ -31,6 +36,12 @@ impl Backend for PgBackend {
 
     fn impl_insert(table: &Table<Self>) -> TokenStream {
         insert::impl_insert(table)
+    }
+
+    fn impl_getters(table: &Table<Self>) -> TokenStream {
+        let mut getters = common::getters::<Self>(table);
+        getters.extend(impl_get_any_getter(table));
+        getters
     }
 }
 

--- a/ormx-macros/src/backend/postgres/mod.rs
+++ b/ormx-macros/src/backend/postgres/mod.rs
@@ -5,11 +5,11 @@ use proc_macro2::TokenStream;
 use crate::backend::Backend;
 use crate::table::Table;
 
-use self::get_any::impl_get_any_getter;
+use self::get_by_any::impl_get_by_any_getter;
 
 use super::common;
 
-mod get_any;
+mod get_by_any;
 mod insert;
 
 #[derive(Clone)]
@@ -40,7 +40,7 @@ impl Backend for PgBackend {
 
     fn impl_getters(table: &Table<Self>) -> TokenStream {
         let mut getters = common::getters::<Self>(table);
-        getters.extend(impl_get_any_getter(table));
+        getters.extend(impl_get_by_any_getter(table));
         getters
     }
 }

--- a/ormx-macros/src/lib.rs
+++ b/ormx-macros/src/lib.rs
@@ -50,7 +50,7 @@ mod utils;
 ///
 /// # Accessors: Getters
 /// ormx will generate accessor functions for fields annotated with `#[ormx(get_one)]`,
-/// `#[ormx(get_optional)]` and `#[ormx(get_many)]`.
+/// `#[ormx(get_optional)]`, `#[ormx(get_many)]` and `#[ormx(get_any)]`.
 /// These functions can be used to query a row by the value of the annotated field.
 ///
 /// The generated function will have these signature:  
@@ -62,6 +62,9 @@ mod utils;
 ///
 /// **`#[ormx(get_many)]`**:  
 /// `{pub} async fn get_by_{field_name}(&{field_type}) -> Result<Vec<Self>>`
+///
+/// **`#[ormx(get_any)]`**:  
+/// `{pub} async fn get_by_{field_name}(&[{field_type}]) -> Result<Vec<Self>>`
 ///
 /// By default, the function will be named `get_by_{field_name)`, though this can be changed by
 /// supplying a custom name: `#[ormx(get_one = by_id)]`.

--- a/ormx-macros/src/lib.rs
+++ b/ormx-macros/src/lib.rs
@@ -50,7 +50,7 @@ mod utils;
 ///
 /// # Accessors: Getters
 /// ormx will generate accessor functions for fields annotated with `#[ormx(get_one)]`,
-/// `#[ormx(get_optional)]`, `#[ormx(get_many)]` and `#[ormx(get_any)]`.
+/// `#[ormx(get_optional)]`, `#[ormx(get_many)]` and `#[ormx(get_by_any)]`.
 /// These functions can be used to query a row by the value of the annotated field.
 ///
 /// The generated function will have these signature:  
@@ -63,8 +63,8 @@ mod utils;
 /// **`#[ormx(get_many)]`**:  
 /// `{pub} async fn get_by_{field_name}(&{field_type}) -> Result<Vec<Self>>`
 ///
-/// **`#[ormx(get_any)]`**:  
-/// `{pub} async fn get_by_{field_name}(&[{field_type}]) -> Result<Vec<Self>>`
+/// **`#[ormx(get_by_any)]`**:  
+/// `{pub} async fn get_by_any_{field_name}(&[{field_type}]) -> Result<Vec<Self>>`
 ///
 /// By default, the function will be named `get_by_{field_name)`, though this can be changed by
 /// supplying a custom name: `#[ormx(get_one = by_id)]`.

--- a/ormx-macros/src/table/mod.rs
+++ b/ormx-macros/src/table/mod.rs
@@ -33,7 +33,7 @@ pub struct TableField<B: Backend> {
     pub get_optional: Option<Getter>,
     pub get_many: Option<Getter>,
     #[cfg(feature = "postgres")]
-    pub get_any: Option<Getter>,
+    pub get_by_any: Option<Getter>,
     pub set: Option<Ident>,
     pub _phantom: PhantomData<*const B>,
 }
@@ -88,7 +88,7 @@ impl<B: Backend> TableField<B> {
 
 impl Getter {
     pub fn or_fallback<B: Backend>(&self, field: &TableField<B>) -> (Ident, Type) {
-        let ident = self.ident_or_fallback(field);
+        let ident = self.ident_or(field, &format!("by_{}", field.field));
         let arg = self.arg_ty.clone().unwrap_or_else(|| {
             let ty = &field.ty;
             syn::parse2(quote!(&#ty)).unwrap()
@@ -96,10 +96,10 @@ impl Getter {
         (ident, arg)
     }
 
-    pub fn ident_or_fallback<B: Backend>(&self, field: &TableField<B>) -> Ident {
+    pub fn ident_or<B: Backend>(&self, field: &TableField<B>, ident: &str) -> Ident {
         self.func
             .clone()
-            .unwrap_or_else(|| Ident::new(&format!("by_{}", field.field), Span::call_site()))
+            .unwrap_or_else(|| Ident::new(ident, Span::call_site()))
     }
 }
 

--- a/ormx-macros/src/table/parse.rs
+++ b/ormx-macros/src/table/parse.rs
@@ -39,7 +39,7 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
         );
 
         #[cfg(feature = "postgres")]
-        none!(get_any);
+        none!(get_by_any);
 
         for attr in parse_attrs::<TableFieldAttr>(&value.attrs)? {
             match attr {
@@ -49,7 +49,7 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
                 TableFieldAttr::GetOptional(g) => set_once(&mut get_optional, g)?,
                 TableFieldAttr::GetMany(g) => set_once(&mut get_many, g)?,
                 #[cfg(feature = "postgres")]
-                TableFieldAttr::GetAny(g) => set_once(&mut get_any, g)?,
+                TableFieldAttr::GetByAny(g) => set_once(&mut get_by_any, g)?,
                 TableFieldAttr::Set(s) => {
                     let default = || Ident::new(&format!("set_{}", ident), Span::call_site());
                     set_once(&mut set, s.unwrap_or_else(default))?
@@ -68,7 +68,7 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
             get_optional,
             get_many,
             #[cfg(feature = "postgres")]
-            get_any,
+            get_by_any,
             set,
             _phantom: PhantomData,
         })

--- a/ormx-macros/src/table/parse.rs
+++ b/ormx-macros/src/table/parse.rs
@@ -38,6 +38,9 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
             default
         );
 
+        #[cfg(feature = "postgres")]
+        none!(get_any);
+
         for attr in parse_attrs::<TableFieldAttr>(&value.attrs)? {
             match attr {
                 TableFieldAttr::Column(c) => set_once(&mut column, c)?,
@@ -45,6 +48,8 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
                 TableFieldAttr::GetOne(g) => set_once(&mut get_one, g)?,
                 TableFieldAttr::GetOptional(g) => set_once(&mut get_optional, g)?,
                 TableFieldAttr::GetMany(g) => set_once(&mut get_many, g)?,
+                #[cfg(feature = "postgres")]
+                TableFieldAttr::GetAny(g) => set_once(&mut get_any, g)?,
                 TableFieldAttr::Set(s) => {
                     let default = || Ident::new(&format!("set_{}", ident), Span::call_site());
                     set_once(&mut set, s.unwrap_or_else(default))?
@@ -62,6 +67,8 @@ impl<B: Backend> TryFrom<&syn::Field> for TableField<B> {
             get_one,
             get_optional,
             get_many,
+            #[cfg(feature = "postgres")]
+            get_any,
             set,
             _phantom: PhantomData,
         })


### PR DESCRIPTION
## Description
This PR adds `get_by_any` getters. These getters will return all records that match any of the provided values/ids.

## Usage
My current use case is a graphql api that utilizes data loaders to avoid N+1 queries:
```rust
#[derive(Debug, Clone, SimpleObject, ormx::Table)]
#[ormx(table = "addresses", id = id, insertable)]
pub struct Address {
    #[ormx(get_optional = get_by_id(&Uuid), get_by_any)]
    pub id: Uuid,
    pub address_line1: Option<String>,
    pub address_line2: Option<String>,
    pub city: Option<String>,
    pub province_code: Option<String>,
    pub country_code: Option<String>,
    pub postal_code: Option<String>
}
```

```rust
#[async_trait]
impl<'a> Loader<Uuid> for AddressDataLoader {
    type Value = Address;

    type Error = Arc<sqlx::Error>;

    async fn load(
        &self,
        keys: &[Uuid],
    ) -> Result<std::collections::HashMap<Uuid, Self::Value>, Self::Error> {
        let mut conn = self.0.acquire().await?;
        let addresses = Address::get_by_any_id(&mut conn, keys).await?; // <- generated getter
        Ok(addresses.into_iter().map(|a| (a.id, a)).collect())
    }
}
```

## Implementation
It generates the following SQL, to be type checked by sqlx: `SELECT {} FROM {} WHERE {} = ANY($1)`.
It is only available for postgres since mysql does not support arrays.