### PR TITLE
fix #[ormx(by_ref)] for non-Copy custom types

### DIFF
--- a/ormx-macros/src/table/mod.rs
+++ b/ormx-macros/src/table/mod.rs
@@ -83,8 +83,10 @@ impl<B: Backend> TableField<B> {
         let ty = &self.ty;
 
         let mut out = quote!(self.#ident);
+        let mut ty = quote!(#ty);
         if self.by_ref {
             out = quote!(&#out);
+            ty = quote!(&#ty);
         }
         if self.custom_type {
             out = quote!(#out as #ty);


### PR DESCRIPTION
This PR aims to fix the combined usage of `#[ormx(by_ref, custom_type)]`:

As an example, let's say I have a non-`Copy` custome `sqlx` type as part of my model, and I want to `#[derive(ormx::Table)]` with the `insertable` option:

```rs
#[derive(sqlx::Type, Clone, Debug)]
#[sqlx(transparent)]
struct EmailAddress(String);

#[ormx::Table, Clone, Debug]
#[ormx(table = "user", id = id, insertable)]
struct User {
  #[ormx(default)]
  id: Uuid,

  #[ormx(custom_type)]
  email: EmailAddress,
}
```

In that case, I get the following error:

```
error[E0507]: cannot move out of `self.email` which is behind a shared reference
  --> src/domain/user.rs:5:10
   |
 5 | #[derive(ormx::Table, Clone, Debug)]
   |          ^^^^^^^^^^^ move occurs because `self.email` has type `EmailAddress`, which does not implement the `Copy` trait
   |
   = note: this error originates in the derive macro `Table` (in Nightly builds, run with -Z macro-backtrace for more info)
```

So naturally, I reach out to the field option `#[ormx(by_ref)]` for `email`:

```diff
-  #[ormx(custom_type)]
+  #[ormx(by_ref, custom_type)]
   email: EmailAddress
```

Now, the error becomes:

```
error[E0605]: non-primitive cast: `&EmailAddress` as `EmailAddress`
  --> server/src/domain/user.rs:5:10
   |
 5 | #[derive(ormx::Table, Clone, Debug)]
   |          ^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
   |
   = note: this error originates in the derive macro `Table` (in Nightly builds, run with -Z macro-backtrace for more info)
```

**tl;dr:** The code generated when both `by_ref` and `custom_type` are used in conjunction doesn't add the `&` to the type in the cast, hence the error. This PR fixes that omission.