### PR TITLE
use impl Executor in Insert::insert instead of &mut Connection

### DIFF
--- a/example-mysql/src/main.rs
+++ b/example-mysql/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
         email: "moritz.bischof1@gmail.com".to_owned(),
         disabled: None,
     }
-    .insert(&mut *db.acquire().await?)
+    .insert(&db)
     .await?;
 
     log::info!("update a single field");

--- a/example-postgres/src/main.rs
+++ b/example-postgres/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
         disabled: None,
         role: Role::User,
     }
-    .insert(&mut *db.acquire().await?)
+    .insert(&db)
     .await?;
 
     log::info!("update a single field");

--- a/ormx-macros/src/backend/mysql/insert.rs
+++ b/ormx-macros/src/backend/mysql/insert.rs
@@ -26,14 +26,16 @@ pub fn impl_insert(table: &Table<MySqlBackend>) -> TokenStream {
         impl ormx::Insert for #insert_ident {
             type Table = #table_ident;
 
-            fn insert(
+            fn insert<'a, 'c: 'a>(
                 self,
-                db: &mut sqlx::MySqlConnection,
-            ) -> #box_future<sqlx::Result<Self::Table>> {
+                db: impl sqlx::Executor<'c, Database = ormx::Db> + 'a,
+            ) -> #box_future<'a, sqlx::Result<Self::Table>> {
                 Box::pin(async move {
+                    let mut tx = db.begin().await?;
                     #insert
                     #query_id
                     #query_default
+                    tx.commit().await?;
                     Ok(#construct_row)
                 })
             }
@@ -85,7 +87,7 @@ fn query_default(table: &Table<MySqlBackend>) -> TokenStream {
 
     quote! {
         let _generated = sqlx::query!(#query_default_sql, _id)
-            .fetch_one(db)
+            .fetch_one(&mut tx)
             .await?;
     }
 }
@@ -104,7 +106,7 @@ fn insert(table: &Table<MySqlBackend>) -> TokenStream {
 
     quote! {
         sqlx::query!(#insert_sql, #( self.#insert_field_idents, )*)
-            .execute(db as &mut sqlx::MySqlConnection)
+            .execute(&mut tx)
             .await?;
     }
 }
@@ -119,7 +121,7 @@ fn query_id(table: &Table<MySqlBackend>) -> TokenStream {
     match table.id.default {
         true => quote! {
             let _id = sqlx::query!("SELECT LAST_INSERT_ID() AS id")
-                .fetch_one(db as &mut sqlx::MySqlConnection)
+                .fetch_one(&mut tx)
                 .await?
                 .id;
         },

--- a/ormx-macros/src/backend/postgres/insert.rs
+++ b/ormx-macros/src/backend/postgres/insert.rs
@@ -66,13 +66,13 @@ pub fn impl_insert(table: &Table<PgBackend>) -> TokenStream {
         impl ormx::Insert for #insert_ident {
             type Table = #table_ident;
 
-            fn insert(
+            fn insert<'a, 'c: 'a>(
                 self,
-                db: &mut sqlx::PgConnection,
-            ) -> #box_future<sqlx::Result<Self::Table>> {
+                db: impl sqlx::Executor<'c, Database = ormx::Db> + 'a,
+            ) -> #box_future<'a, sqlx::Result<Self::Table>> {
                 Box::pin(async move {
                     let _generated = sqlx::query!(#insert_sql, #( #insert_field_exprs, )*)
-                        .#fetch_funtion(db as &mut sqlx::PgConnection)
+                        .#fetch_funtion(db)
                         .await?;
 
                     Ok(Self::Table {

--- a/ormx/src/lib.rs
+++ b/ormx/src/lib.rs
@@ -194,5 +194,8 @@ where
     type Table: Table;
 
     /// Insert a row into the database, returning the inserted row.
-    fn insert(self, db: &mut <Db as Database>::Connection) -> BoxFuture<Result<Self::Table>>;
+    fn insert<'a, 'c: 'a>(
+        self,
+        db: impl Executor<'c, Database = Db> + 'a,
+    ) -> BoxFuture<'a, Result<Self::Table>>;
 }


### PR DESCRIPTION
This implements the solution discussed in https://github.com/NyxCode/ormx/issues/22#issuecomment-1010043291

⚠️ Please beware that this is a **BREAKING CHANGE** ⚠️ 

Essentially, it allows to use the same API `db: impl Executor<...>` in `Insert::insert` instead of the odd `db: &mut Connection<...>`.
The reason for that special case was to fetch the newly created `id` for MySQL by reusing the connection.

This solution implements that by opening a transaction when generating `Insert::insert` for MySQL.