### PR TITLE
Derive Serialize and Deserialize for the generated insert structs

### DIFF
--- a/ormx-macros/Cargo.toml
+++ b/ormx-macros/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 sqlite = []
 mysql = []
 postgres = []
+serde = ["dep:serde"]
 
 [dependencies]
 itertools = "0.10"
@@ -22,3 +23,4 @@ quote = "1"
 syn = { version = "1", features = ["full"] }
 once_cell = "1"
 proc-macro-error = "1"
+serde = { version = "1.0.136", features = ["derive"], optional = true }

--- a/ormx-macros/src/backend/common/mod.rs
+++ b/ormx-macros/src/backend/common/mod.rs
@@ -210,7 +210,17 @@ pub(crate) fn insert_struct<B: Backend>(table: &Table<B>) -> TokenStream {
     });
 
     let from_impl = impl_from_for_insert_struct(table, ident);
+
+    let derive = if cfg!(feature = "serde") {
+        quote! {
+            #[derive(Serialize, Deserialize)]
+        }
+    } else {
+        quote!()
+    };
+
     quote! {
+        #derive
         #(#attrs)*
         #vis struct #ident {
             #( #insert_fields, )*

--- a/ormx/Cargo.toml
+++ b/ormx/Cargo.toml
@@ -16,6 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 mysql = ["sqlx/mysql", "ormx-macros/mysql"]
 sqlite = ["sqlx/sqlite", "ormx-macros/sqlite"]
 postgres = ["sqlx/postgres", "ormx-macros/postgres"]
+serde = ["ormx-macros/serde"]
 
 _docs-rs-build = ["sqlx/runtime-tokio-rustls", "postgres"]
 


### PR DESCRIPTION
I added a new feature called `serde` to derive `serde`'s `Serialize` and `Deserialize` traits for the generated insert structs when enabled.

This way, these structs can be easily used in web applications built with frameworks or libraries that require the structs that represent a request's body to be serializable to and deserializable from a JSON document.