### PR TITLE
:sparkles: Added serde derive behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
-members = ["ormx-macros", "ormx", "example-postgres", "example-mariadb", "example-mysql"]
+members = [
+    "ormx-macros",
+    "ormx",
+    "example-postgres",
+    "example-mariadb",
+    "example-mysql",
+]
 resolver = "2"

--- a/ormx-macros/Cargo.toml
+++ b/ormx-macros/Cargo.toml
@@ -15,6 +15,7 @@ sqlite = []
 mysql = []
 mariadb = []
 postgres = []
+serde = []
 
 [dependencies]
 itertools = "0.13.0"

--- a/ormx-macros/src/backend/common/mod.rs
+++ b/ormx-macros/src/backend/common/mod.rs
@@ -206,9 +206,19 @@ pub(crate) fn insert_struct<B: Backend>(table: &Table<B>) -> TokenStream {
         quote!(#(#attrs)* #vis #ident: #ty)
     });
 
+    let serde_derive = if cfg!(feature = "serde") {
+        quote! {
+            #[derive(::serde::Serialize, ::serde::Deserialize)]
+        }
+    } else {
+        quote! {}
+    };
+
     let from_impl = impl_from_for_insert_struct(table, ident);
     quote! {
         #(#attrs)*
+        #[derive(Debug, Clone)]
+        #serde_derive
         #vis struct #ident {
             #( #insert_fields, )*
         }

--- a/ormx-macros/src/table/parse.rs
+++ b/ormx-macros/src/table/parse.rs
@@ -87,7 +87,7 @@ impl<B: Backend> TryFrom<&DeriveInput> for Table<B> {
                 TableAttr::Table(x) => set_once(&mut table, x)?,
                 TableAttr::Id(x) => set_once(&mut id, x)?,
                 TableAttr::Insertable(x) => {
-                    let default = move || Insertable {
+                    let default = || Insertable {
                         attrs: vec![],
                         ident: Ident::new(&format!("Insert{}", value.ident), Span::call_site()),
                     };

--- a/ormx-macros/src/table/parse.rs
+++ b/ormx-macros/src/table/parse.rs
@@ -87,7 +87,7 @@ impl<B: Backend> TryFrom<&DeriveInput> for Table<B> {
                 TableAttr::Table(x) => set_once(&mut table, x)?,
                 TableAttr::Id(x) => set_once(&mut id, x)?,
                 TableAttr::Insertable(x) => {
-                    let default = || Insertable {
+                    let default = move || Insertable {
                         attrs: vec![],
                         ident: Ident::new(&format!("Insert{}", value.ident), Span::call_site()),
                     };

--- a/ormx/Cargo.toml
+++ b/ormx/Cargo.toml
@@ -17,6 +17,7 @@ mysql = ["sqlx/mysql", "ormx-macros/mysql"]
 mariadb = ["sqlx/mysql", "ormx-macros/mariadb"]
 sqlite = ["sqlx/sqlite", "ormx-macros/sqlite"]
 postgres = ["sqlx/postgres", "ormx-macros/postgres"]
+serde = ["ormx-macros/serde"]
 
 _docs-rs-build = ["sqlx/runtime-tokio-rustls", "postgres"]
 


### PR DESCRIPTION
Hello,

For the purpose of my project, I needed the ability to have the Insert{} struct derive multiple common trait, as well as the serde traits.

To avoid breaking change due to multiple implementations, it is locked behind a feature flag