### PR TITLE
Fix schema-qualified table names for PostgreSQL

### DIFF
--- a/example-postgres/migrations/20250119000000_schema_qualified.sql
+++ b/example-postgres/migrations/20250119000000_schema_qualified.sql
@@ -1,0 +1,9 @@
+-- Test schema-qualified table names
+CREATE SCHEMA IF NOT EXISTS app;
+
+CREATE TABLE app.products
+(
+    id    SERIAL PRIMARY KEY,
+    name  VARCHAR(128) NOT NULL,
+    price FLOAT8 NOT NULL
+);

--- a/example-postgres/src/main.rs
+++ b/example-postgres/src/main.rs
@@ -102,6 +102,17 @@ struct Test {
     rows: Vec<String>,
 }
 
+// Example using a schema-qualified table name
+#[derive(Debug, ormx::Table)]
+#[ormx(table = "app.products", id = id, insertable, deletable)]
+struct Product {
+    #[ormx(default)]
+    id: i32,
+    #[ormx(by_ref)]
+    name: String,
+    price: f64,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
@@ -175,6 +186,22 @@ async fn main() -> anyhow::Result<()> {
 
     info!("delete the user from the database..");
     new.delete(&mut *tx).await?;
+
+
+    info!("test schema-qualified table name (app.products)..");
+    let product = InsertProduct {
+        name: "Widget".to_owned(),
+        price: 19.99,
+    }
+    .insert(&mut *tx)
+    .await?;
+    info!("inserted product with id {}", product.id);
+
+    let fetched = Product::get(&mut *tx, product.id).await?;
+    info!("fetched product: {:?}", fetched);
+
+    product.delete(&mut *tx).await?;
+    info!("deleted product");
 
 
     Ok(())

--- a/ormx-macros/src/table/mod.rs
+++ b/ormx-macros/src/table/mod.rs
@@ -62,7 +62,13 @@ impl<B: Backend> Table<B> {
 
     pub fn name(&self) -> String {
         let q = B::QUOTE;
-        format!("{q}{}{q}", self.table)
+        // Handle schema-qualified table names (e.g., "schema.table")
+        // by quoting each part separately
+        self.table
+            .split('.')
+            .map(|part| format!("{q}{part}{q}"))
+            .collect::<Vec<_>>()
+            .join(".")
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where schema-qualified table names (e.g., `schema.table`) were being incorrectly quoted in generated SQL.

### The Problem

When using a table name like `yahoo.exchanges`:

```rust
#[derive(ormx::Table)]
#[ormx(table = "yahoo.exchanges", id = id)]
struct Exchange { ... }
```

The generated SQL would quote the entire name as `"yahoo.exchanges"`, which PostgreSQL interprets as a single identifier containing a literal dot character. This causes errors like:

```
error returned from database: relation "yahoo.exchanges" does not exist
```

### The Fix

The `name()` method now splits the table name on `.` and quotes each part separately, producing `"yahoo"."exchanges"` which PostgreSQL correctly interprets as schema + table.

### Testing

- Added a new migration and example in `example-postgres` that creates an `app` schema with a `products` table
- The example demonstrates using `#[ormx(table = "app.products", ...)]` 
- Verified the example runs successfully against a local PostgreSQL database